### PR TITLE
Allow overriding values from a config file

### DIFF
--- a/control.sh
+++ b/control.sh
@@ -24,6 +24,13 @@ STRIP_HUE=39
 STRIP_SATURATION=15
 #STRIP_BRIGHTNESS=100 # Hardcode the brightness... OR:
 STRIP_PERCENTAGE_OF_LIGHT=800 # Set it to a percentage of the main light.
+
+# Override the default light and strip values with a custom config file.
+# =====================
+CONFIG_PATH="$HOME/.bashgato.sh"
+if [ -f $CONFIG_PATH ]; then
+	source $CONFIG_PATH
+fi
 ###############################################################################
 
 # Get the current script dir.


### PR DESCRIPTION
* Hardcoded the location at `~/.bashgato.sh`
* Loading a shell file seemed the simplest – just assign a bunch of variables.
* Too lazy to add a CLI option to load from a different location.

Here is what my config looks like:

```shell
LIGHT_IPS=(192.168.0.37)
LIGHT_INCREMENT=10
LIGHT_TEMPERATURE=250
STRIP_IPS=()
```

I don't use a strip and also I interact via Alfred commands, not through a rotary dial. Without a config file merging would have been probably quite hard and I would have never upgraded :-)

Unrelated, the comment came straight from Copilot (cc @helen):

<img width="930" alt="Screen Shot 2022-11-08 at 13 02 48" src="https://user-images.githubusercontent.com/27954/200554248-360aa946-6934-4888-942e-491891cd049d.png">
